### PR TITLE
Make scripts OSX compatible

### DIFF
--- a/conda-env.fish
+++ b/conda-env.fish
@@ -1,5 +1,9 @@
+function get_realpath
+    echo (python -c "from __future__ import print_function;import os,sys;print(os.path.realpath(sys.argv[1]))" $argv[1])
+end
+
 function get_dirname -d 'get the dir containing the given file'
-	echo (realpath (dirname $argv[1]))
+	echo (get_realpath (dirname $argv[1]))
 end
 
 function print_help 
@@ -10,7 +14,7 @@ end
 set argc (echo (count $argv))
 
 set _THIS_DIR (get_dirname (status --current-filename))
-set _FISH_FUNCTIONS_DIR (realpath ~/.config/fish/functions)
+set _FISH_FUNCTIONS_DIR (get_realpath ~/.config/fish/functions)
 set _CONDA_ROOT_DIR (python -c "from __future__ import print_function; from conda.config import root_dir; print(root_dir)")
 set _CONDA_BIN_DIR (echo $_CONDA_ROOT_DIR"/bin")
 

--- a/conda/activate.fish
+++ b/conda/activate.fish
@@ -1,7 +1,11 @@
 #!/usr/local/bin/fish
 
+function get_realpath
+    echo (python -c 'from __future__ import print_function;import os,sys;print(os.path.realpath(sys.argv[1]))' $argv)
+end
+
 function get_dirname -d 'get the dir containing the given file'
-	echo (realpath (dirname $argv[1]))
+	echo (get_realpath (dirname $argv[1]))
 end
 
 function run_scripts -d 'run all scripts in a directory'

--- a/conda/deactivate.fish
+++ b/conda/deactivate.fish
@@ -1,7 +1,11 @@
 #!/usr/local/bin/fish
 
+function get_realpath
+    echo (python -c 'from __future__ import print_function;import os,sys;print(os.path.realpath(sys.argv[1]))' $argv)
+end
+
 function get_dirname -d 'get the dir containing the given file'
-	echo (realpath (dirname $argv[1]))
+	echo (get_realpath (dirname $argv[1]))
 end
 
 function run_scripts -d 'run all scripts in a directory'


### PR DESCRIPTION
Mac OSX doesn't have a built-in `realpath` command like Linux machines do.  So
this modification creates a new function `get_realpath` in the spirit of `get_dirname`
already implemented, to perform the same action.
